### PR TITLE
Implement __len__ and __nonzero__ where appropriate.

### DIFF
--- a/hl7.py
+++ b/hl7.py
@@ -107,6 +107,8 @@ class HL7Segment(object):
         # shift index one down, since the type field is ignored
         return self.fields[idx + 1]
 
+    def __len__(self):
+        return len(self.fields) - 1
 
 
 

--- a/hl7_data_types.py
+++ b/hl7_data_types.py
@@ -92,6 +92,18 @@ class HL7DataType(object):
     def __getitem__(self, idx):
         return self.input_fields[idx]
 
+    def __len__(self):
+        return len(self.input_fields)
+
+    def __nonzero__(self):
+        if not self.field_map and hasattr(self, "value"):
+            return bool(self.value)
+        elif len(self.input_fields) == 1:
+            return bool(self.input_fields[0])
+        elif len(self.input_fields) > 1:
+            return True
+
+
 class HL7RepeatingField(object):
     """ generic repeating field """
     def __init__(self, Type, composite, delimiters):
@@ -196,6 +208,9 @@ class HL7Datetime(HL7DataType):
 
     def __unicode__(self):
         return self.__str__()
+
+    def __nonzero__(self):
+        return not self.isNull
 
 
 class HL7_SI(HL7DataType):

--- a/test.py
+++ b/test.py
@@ -56,6 +56,38 @@ class TestParsing(unittest.TestCase):
         self.assertEqual(unicode(pid.ssn_number_patient), '')
         self.assertEqual(unicode(pid), pid_string)
 
+    def test_len(self):
+        pid_string = "PID|1||PATID1234^^M11^ADT1^MR^HOSPITAL||EVERYMAN^ADAM^A^III||||||&HOME STREET&2^^Greensboro^NC^27401-1020^Westeros|"
+        pid = HL7Segment(pid_string)
+        # segment length
+        self.assertEqual(len(pid), 40)
+        # named field set
+        self.assertTrue(pid.set_id_pid)
+        # named field unset
+        self.assertFalse(pid.ssn_number_patient)
+        # HL7Datetime unset
+        self.assertFalse(pid.datetime_of_birth)
+        # list field set
+        self.assertTrue(pid.patient_identifier_list)
+        # list field length
+        self.assertEqual(len(pid.patient_identifier_list), 1)
+        self.assertTrue(pid.patient_identifier_list[0])
+        self.assertFalse(pid.patient_identifier_list[0].identifier_check_digit)
+
+        # test unrecognized segment
+        pid = HL7Segment("LOL|VALUE||^^^|")
+        self.assertEqual(len(pid), 4)
+        # value field set
+        self.assertTrue(pid[0])
+        self.assertEqual(len(pid[0]), 1)
+        # value field unset
+        self.assertFalse(pid[1])
+        # list field set
+        self.assertTrue(pid[2])
+        self.assertEqual(len(pid[2]), 4)
+        # list field element unset
+        self.assertFalse(pid[2][0])
+
     def test_message_parse(self):
         message = HL7Message(self.msg_string1)
 


### PR DESCRIPTION
This allows named fields to be tested e.g.
if m.pid.ssn_number_patient: ...
