### PR TITLE
Handle HL7 dates before year 1900. Properly parse the fractional seconds...

### DIFF
--- a/hl7_data_types.py
+++ b/hl7_data_types.py
@@ -167,10 +167,11 @@ class HL7Datetime(HL7DataType):
             if precision >= 14: second = int(composite[12:14])
             else: second = 0
 
-            if precision >= 16: tenth_second = int(composite[14:16])
+            # Skip the "." separator
+            if precision >= 17: tenth_second = int(composite[15:17])
             else: tenth_second = 0
 
-            if precision >= 19: microsecond = int(composite[16:19]) * 100
+            if precision >= 19: microsecond = int(composite[17:19]) * 100
             else: microsecond = 0
 
             if precision == 24: timezone = composite[19:24]
@@ -192,7 +193,8 @@ class HL7Datetime(HL7DataType):
         if self.isNull:
             return ""
         else:
-            return self.datetime.strftime('%Y%m%d%H%M%S')[:self.precision]
+            # HL7 dates are ISO 8601 without the decorators, i.e. "YYYYMMDDHHMMSS.UUUU[+|-ZZzz]"
+            return self.datetime.isoformat(str('-')).translate(None, str("-:"))[:self.precision]
 
     def __unicode__(self):
         return self.__str__()

--- a/test.py
+++ b/test.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from hl7 import HL7Message, HL7Segment, HL7Delimiters
+from hl7_data_types import HL7Datetime
 
 import unittest
 
@@ -29,6 +30,13 @@ class TestParsing(unittest.TestCase):
     def test_datetime(self):
         message = HL7Message(self.msg_string1)
         self.assertEqual(unicode(message.pid.datetime_of_birth), '19610615')
+        delimiters = HL7Delimiters(*"|^~\&")
+        old = "18710826"
+        dt = HL7Datetime(old, delimiters)
+        self.assertEqual(unicode(dt), old)
+        time = "19610615132733.0065"
+        dt = HL7Datetime(time, delimiters)
+        self.assertEqual(unicode(dt), time)
 
     def test_address(self):
         message = HL7Message(self.msg_string1)


### PR DESCRIPTION
....

strftime() raises an exception for years before 1900.
Since HL7 dates are ISO 8601 but without the separators
(except for "."), use isoformat() and remove the separators.

Based on this description:

The value of a point in time is represented using the ISO 8601 compliant form traditionally in use with HL7. This is the form that has no decorating dashes, colons and no “T” between the date and time. In short, the syntax is “YYYYMMDDHHMMSS.UUUU[+|-ZZzz]” where digits can be omitted from the right side to express less precision. Common forms are “YYYYMMDD” and “YYYYMMDDHHMM”, but the ability to truncate on the right side is not limited to these two variants.
http://www.hl7standards.com/blog/2008/07/25/hl7-time-zone-qualification/
