### PR TITLE
Raise AttributeError on invalid message attributes.

### DIFF
--- a/hl7parser/hl7.py
+++ b/hl7parser/hl7.py
@@ -151,8 +151,6 @@ class HL7Message(object):
         self.header = self.msh
         self.type = self.header.fields[8]
 
-
-
     def __getattr__(self, attr):
         if attr in self.segment_position:
             positions = self.segment_position[attr]
@@ -161,8 +159,7 @@ class HL7Message(object):
             else:
                 return self.segments[positions][1]
         else:
-            return getattr(self, attr)
-
+            raise AttributeError("{0!r} object has no attribute {1!r}".format(self.__class__, attr))
 
     def __unicode__(self):
         return "\n".join([unicode(x[1]) for x in self.segments])

--- a/hl7parser/tests/test_parse.py
+++ b/hl7parser/tests/test_parse.py
@@ -142,6 +142,10 @@ class TestParsing(unittest.TestCase):
 
         self.assertEqual("2.7", unicode(message.header.version_id.version_id))
 
+        def invalid_attr():
+            message.foobar
+        self.assertRaises(AttributeError, invalid_attr)
+
     def test_unknown_message_parse(self):
         message = HL7Message(self.msg_string1)
 


### PR DESCRIPTION
Current behavior is to infinitely recurse until RuntimeError: maximum recursion depth exceeded
