### PR TITLE
Feat/15 support in1 policy number

### DIFF
--- a/hl7parser/hl7.py
+++ b/hl7parser/hl7.py
@@ -64,6 +64,7 @@ class HL7Delimiters(object):
 
 
 class HL7Segment(object):
+
     def __init__(self, segment, delimiters=None):
         if delimiters is None:
             self.delimiters = HL7Delimiters(*"|^~\&")
@@ -88,8 +89,18 @@ class HL7Segment(object):
 
         # iterate over predefined fields, remember index in `named_fields`
         # and initialize fields
+        index_override_found = False
         for index, definition in enumerate(self.field_definitions):
-            self.named_fields[definition[0]] = index
+            if definition[1]["index"] is not None:
+                definition_index = definition[1]["index"]
+                index_override_found = True
+            else:
+                if index_override_found:
+                    raise Exception("Regular cell type after one with index override found")
+                definition_index = index
+            self.named_fields[definition[0]] = definition_index
+            while len(self.fields) != definition_index:
+                self.fields.append(data_types.HL7DataType("", self.delimiters))
             self.fields.append(definition[1]["type"]("", self.delimiters))
 
         # fill fields with initial content

--- a/hl7parser/hl7_data_types.py
+++ b/hl7parser/hl7_data_types.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from datetime import datetime
 
 
-def make_cell_type(name, options=None):
+def make_cell_type(name, options=None, index=None):
     """
     helper method used to configure HL7DataType field maps. Provides some
     sensible default values for HL7 data types.
@@ -12,7 +12,8 @@ def make_cell_type(name, options=None):
     default_options = {
         'required': False,
         'repeats': False,
-        'type': HL7DataType
+        'type': HL7DataType,
+        'index': index,
     }
     if options is None:
         options = {}

--- a/hl7parser/hl7_segments.py
+++ b/hl7parser/hl7_segments.py
@@ -310,6 +310,7 @@ segment_maps = {
         make_cell_type("plan_expiration_date", options={"type": HL7Datetime}),
         make_cell_type("authorization_information"),
         make_cell_type("plan_type", options={"type": HL7_CodedWithException}),
+        make_cell_type("policy_number", index=35)
         # NOTE: standard defines more fields which can be added if needed in
         # the future
     ]

--- a/hl7parser/tests/test_hl7.py
+++ b/hl7parser/tests/test_hl7.py
@@ -2,9 +2,10 @@
 from __future__ import unicode_literals
 
 import pytest
+import mock
 
 from hl7parser.hl7 import HL7Segment
-from hl7parser.hl7_data_types import HL7DataType, HL7Datetime
+from hl7parser.hl7_data_types import HL7DataType, HL7Datetime, make_cell_type
 
 
 def test_hl7_segment_require_length():
@@ -45,3 +46,19 @@ def test_hl7_segment_field_assignment_error():
 
     with pytest.raises(AttributeError):
         segment.something
+
+
+def test_invalid_segment_definition():
+    """ cell types with "index" definition must come at the end """
+
+    segment_maps = {
+        "foo": [
+            make_cell_type('foo'),
+            make_cell_type('bar', index=3),
+            make_cell_type('baz'),
+        ]
+    }
+
+    with mock.patch("hl7parser.hl7.segment_maps", segment_maps):
+        with pytest.raises(Exception):
+            HL7Segment("foo|1|2|3")

--- a/hl7parser/tests/test_hl7.py
+++ b/hl7parser/tests/test_hl7.py
@@ -1,0 +1,47 @@
+# -*- encoding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+
+from hl7parser.hl7 import HL7Segment
+from hl7parser.hl7_data_types import HL7DataType, HL7Datetime
+
+
+def test_hl7_segment_require_length():
+    segment = HL7Segment("ABC|1|2")
+
+    assert len(segment) == 2
+
+    # requiring less fields than already present should do nothing
+    segment.require_length(2)
+    assert len(segment) == 2
+
+    segment.require_length(10)
+    assert len(segment) == 10
+
+
+def test_hl7_segment_field_assignment_generic():
+    segment = HL7Segment("")
+
+    segment[3] = "ABC"
+
+    assert isinstance(segment.fields[3], HL7DataType)
+    assert str(segment) == "||||ABC"
+
+
+def test_hl7_segment_field_assignment_predefined():
+    segment = HL7Segment("EVN|123|20000101|")
+
+    segment[2] = "20010101"
+
+    assert isinstance(segment.fields[2], HL7Datetime)
+
+
+def test_hl7_segment_field_assignment_error():
+    segment = HL7Segment("")
+
+    with pytest.raises(TypeError):
+        segment["Hello"] = "ABC"
+
+    with pytest.raises(AttributeError):
+        segment.something

--- a/hl7parser/tests/test_parse.py
+++ b/hl7parser/tests/test_parse.py
@@ -264,15 +264,18 @@ class TestParsing(unittest.TestCase):
         self.assertEqual(
             unicode(segment.hospital_service), "SUR")
 
+
 def test_in1_segment():
     message_data = (
-        "IN1|1:1|BKK|108035612|mhplus BKK|^^Ludwigsburg^^71636^DEU|||||"
-        "BKK093^1^^OKOG^J^1||20090101|||5000^1|XX^XX^F^^^^L||1953XXXX|"
-        "XXXX  10&XXXXX&10^^XXXXX^^77704^DEU^L||H|1|||||||20180829100800+0100"
-        "||||||1|Y2401XXXXX|||||||W||S||||Y2401XXXXX"
+        "IN1|1:1|McDH||McDonalds Health||||||"
+        "|||||||||"
+        "||||||||||"
+        "||||||1|12345|||||||||||||"
     )
 
     in1 = HL7Segment(message_data)
 
-    assert str(in1.health_plan_id) == "BKK"
-    assert str(in1.insurance_company_name) == "mhplus BKK"
+    assert str(in1.health_plan_id) == "McDH"
+    assert str(in1.insurance_company_name) == "McDonalds Health"
+
+    assert str(in1.policy_number) == "12345"

--- a/hl7parser/tests/test_parse.py
+++ b/hl7parser/tests/test_parse.py
@@ -108,7 +108,7 @@ class TestParsing(unittest.TestCase):
 
         pid_seg = self.msg_string1.splitlines()[2]
 
-        self.assertEqual(unicode(message.pid), pid_seg)
+        assert unicode(message.pid) == pid_seg
 
     def test_multiple_segments_parse(self):
         message = HL7Message(self.msg_string1)
@@ -120,7 +120,7 @@ class TestParsing(unittest.TestCase):
         self.assertEqual(unicode(message.nk1[2]), lines[5])
 
     def test_trailing_segment_fields(self):
-        pid_string = "PID|1||PATID1234^5^M11^ADT1^MR^GOOD HEALTH HOSPITAL~123456789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19610615|M||C|&HOME STREET&2^^Greensboro^NC^27401-1020^Westeros|GL|(555) 555-2004|(555)555-2004"
+        pid_string = "PID|1||PATID1234^5^M11^ADT1^MR^GOOD HEALTH HOSPITAL~123456789^^^USSSA^SS||EVERYMAN^ADAM^A^III||19610615|M||C|&HOME STREET&2^^Greensboro^NC^27401-1020^Westeros|GL|(555) 555-2004|(555)555-2004|"
         pid = HL7Segment(pid_string)
         self.assertEqual(unicode(pid.ssn_number_patient), '')
         self.assertEqual(unicode(pid), pid_string)
@@ -263,3 +263,16 @@ class TestParsing(unittest.TestCase):
 
         self.assertEqual(
             unicode(segment.hospital_service), "SUR")
+
+def test_in1_segment():
+    message_data = (
+        "IN1|1:1|BKK|108035612|mhplus BKK|^^Ludwigsburg^^71636^DEU|||||"
+        "BKK093^1^^OKOG^J^1||20090101|||5000^1|XX^XX^F^^^^L||1953XXXX|"
+        "XXXX  10&XXXXX&10^^XXXXX^^77704^DEU^L||H|1|||||||20180829100800+0100"
+        "||||||1|Y2401XXXXX|||||||W||S||||Y2401XXXXX"
+    )
+
+    in1 = HL7Segment(message_data)
+
+    assert str(in1.health_plan_id) == "BKK"
+    assert str(in1.insurance_company_name) == "mhplus BKK"

--- a/tox.ini
+++ b/tox.ini
@@ -10,5 +10,6 @@ envlist = py27
 deps =
     pytest
     pytest-coverage
+    mock
 commands =
     pytest


### PR DESCRIPTION
First commit adds support for item assignments, so content can be assigned to segments using their index:

```python
message.in1[10] = "foo"
```

This is useful when writing tests.

The second commit adds support for index override in cell definition. This means that when defining cells for a specific segments in `hl7_segments.py`, you don't have to write down all cells until you get to the one you're interested in.

Example:

```python
segment_maps = {
    'FOO': [
        make_cell_type('bar'),
        make_cell_type('bar'),
        make_cell_type('bam', index=12),
   ]
}
```

Before this change, you'd have to write down all 12 cells.

Finally, the last commit uses this to define `policy_number` for `IN1` segments.