### PR TITLE
fix(HL7Datetime): Add partial support for old TM format

### DIFF
--- a/hl7parser/hl7_data_types.py
+++ b/hl7parser/hl7_data_types.py
@@ -168,12 +168,22 @@ class HL7Datetime(HL7DataType):
     """
         HL7 datetime data type
 
+        Complete Supports the DTM format and only partial support for the older TM format,
+        which is deprecated since hl7 2.6.
+        If the datetime is given in TM format the second component is ignored, because its not
+        reliable and the first component is treated like the DTM formatted datetime.
+
         example input:
             198808181126
     """
     component_map = ['datetime']
 
-    def __init__(self, composite, delimiter, use_delimiter="subcomponent_separator"):
+    def __init__(self, composite, delimiters, use_delimiter="component_separator"):
+
+        delimiter = getattr(delimiters, use_delimiter)
+        composite = composite.split(delimiter)
+        composite = composite[0]
+
         if len(composite) == 0:
             self.datetime = ""
             self.isNull = True

--- a/tests/data_types.py
+++ b/tests/data_types.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import pytest
 
+from hl7parser.hl7 import HL7Delimiters
 from hl7parser.hl7_data_types import HL7Datetime
 
 
@@ -13,9 +14,12 @@ from hl7parser.hl7_data_types import HL7Datetime
         ("", "", ""),
         ("2010", "2010-01-01T00:00:00", "2010"),
         ("-200", "", ""),
+        ("20190924143134^YYYYMMDDHHMMSS", "2019-09-24T14:31:34", "20190924143134")
     ]
 )
 def test_datetime(input_string, isoformat, string_repr):
-    dt = HL7Datetime(input_string, "|")
+
+    delimiters = HL7Delimiters(*"|^~\&")
+    dt = HL7Datetime(input_string, delimiters)
     assert dt.isoformat() == isoformat
     assert str(dt) == string_repr

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -10,6 +10,8 @@ import unittest
 import six
 import sys
 import pytest
+import datetime
+
 
 @pytest.mark.skipif(sys.version_info.major > 2, reason="not relevant for python 3")
 def test_bytestring_segment():
@@ -241,7 +243,8 @@ class TestParsing(unittest.TestCase):
 
     def test_pv1_segment(self):
         segment = HL7Segment(
-            "PV1|1|I|2000^2012^01||||004777^ATTEND^AARON^A|||SUR||||ADM|A0|"
+            "PV1|1|I|2000^2012^01||123^^^^^^20190924143134&YYYYMMDDHHMMSS"
+            "||004777^ATTEND^AARON^A|||SUR||||ADM|A0|"
         )
 
         self.assertEqual(six.text_type(segment.patient_class), "I")
@@ -265,6 +268,9 @@ class TestParsing(unittest.TestCase):
 
         self.assertEqual(
             six.text_type(segment.hospital_service), "SUR")
+
+        self.assertEqual(
+            six.text_type(segment.preadmit_number.effective_date.datetime), "2019-09-24 14:31:34")
 
 
 def test_in1_segment():


### PR DESCRIPTION
There are two formats for datetimes in hl7, the new DTM format and the older TM format.

The DTM format consits of only one component and is already fully supported by this hl7-parser

The TM format is deprecated since hl7 2.6 and consisted of two component whereby the second component was meant do give the precision. 

According to [this articel](http://wiki.hl7.de/index.php?title=V25dt:TS) the second component was never reliable, therefore this PR ignores the second component of any datetime field (if there is one), the first component is always threaded as a DTM formatted datetime value.

fix #23