### PR TITLE
feat(segment): Add insured's address to IN1 segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## Version 0.7.2 (2022-04-12)
+## Version 0.7.2 (2022-04-13)
 
 * Adds insured's address to IN1 segment
+* Adds partial support for old TM format.
 ## Version 0.7.1 (2019-07-11)
 
 * Fixes a bug with datetimes extended composite id block (https://github.com/mps-gmbh/hl7-parser/issues/21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Version 0.7.2 (2022-04-12)
+
+* Adds insured's address to IN1 segment
 ## Version 0.7.1 (2019-07-11)
 
 * Fixes a bug with datetimes extended composite id block (https://github.com/mps-gmbh/hl7-parser/issues/21)

--- a/hl7parser/hl7_segments.py
+++ b/hl7parser/hl7_segments.py
@@ -310,7 +310,7 @@ segment_maps = {
         make_cell_type("plan_expiration_date", options={"type": HL7Datetime}),
         make_cell_type("authorization_information"),
         make_cell_type("plan_type", options={"type": HL7_CodedWithException}),
-        make_cell_type("name_of_insured"),
+        make_cell_type("name_of_insured", options={"type": HL7_ExtendedPersonName}),
         make_cell_type("insureds_relationship_to_patient"),
         make_cell_type("insureds_date_of_birth"),
         make_cell_type(

--- a/hl7parser/hl7_segments.py
+++ b/hl7parser/hl7_segments.py
@@ -310,7 +310,14 @@ segment_maps = {
         make_cell_type("plan_expiration_date", options={"type": HL7Datetime}),
         make_cell_type("authorization_information"),
         make_cell_type("plan_type", options={"type": HL7_CodedWithException}),
-        make_cell_type("policy_number", index=35)
+        make_cell_type("name_of_insured"),
+        make_cell_type("insureds_relationship_to_patient"),
+        make_cell_type("insureds_date_of_birth"),
+        make_cell_type(
+            "insureds_address",
+            options={"type": HL7_ExtendedAddress, "required": False, "repeats": False},
+        ),
+        make_cell_type("policy_number", index=36)
         # NOTE: standard defines more fields which can be added if needed in
         # the future
     ]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='hl7parser',
-    version='0.7.1',
+    version='0.7.2',
     description='A simple HL7 parser',
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -276,7 +276,7 @@ class TestParsing(unittest.TestCase):
 def test_in1_segment():
     message_data = (
         "IN1|1:1|McDH|123456789^^^^^^^^^McDonalds Health|McDonalds Health||||||"
-        "|||||||||Königstr. 1B^^Stuttgart^^70173|"
+        "||||||Musterfrau^Gertrud^^^^Dr.^L^A^|SEL|19700101|Königstr. 1B^^Stuttgart^^70173|"
         "||||||||||"
         "||||||1|12345|||||||||||||"
     )
@@ -287,6 +287,21 @@ def test_in1_segment():
     assert str(in1.insurance_company_name) == "McDonalds Health"
 
     assert str(in1.policy_number) == "12345"
+
+    name_of_insured = in1.name_of_insured
+    assert str(name_of_insured) == "Musterfrau^Gertrud^^^^Dr.^L^A^"
+    assert str(name_of_insured.family_name) == "Musterfrau"
+    assert str(name_of_insured.given_name) == "Gertrud"
+    assert str(name_of_insured.middle_name) == ''
+    assert str(name_of_insured.suffix) == ''
+    assert str(name_of_insured.prefix) == ''
+    assert str(name_of_insured.degree) == "Dr."
+    assert str(name_of_insured.name_type_code) == "L"
+    assert str(name_of_insured.name_representation_code) == "A"
+    assert str(name_of_insured.name_context) == ""
+
+    assert str(in1.insureds_relationship_to_patient) == "SEL"
+    assert str(in1.insureds_date_of_birth) == "19700101"
 
     insureds_address = in1.insureds_address
     assert str(insureds_address) == "Königstr. 1B^^Stuttgart^^70173"

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -276,7 +276,7 @@ class TestParsing(unittest.TestCase):
 def test_in1_segment():
     message_data = (
         "IN1|1:1|McDH|123456789^^^^^^^^^McDonalds Health|McDonalds Health||||||"
-        "|||||||||"
+        "|||||||||Königstr. 1B^^Stuttgart^^70173|"
         "||||||||||"
         "||||||1|12345|||||||||||||"
     )
@@ -287,3 +287,9 @@ def test_in1_segment():
     assert str(in1.insurance_company_name) == "McDonalds Health"
 
     assert str(in1.policy_number) == "12345"
+
+    insureds_address = in1.insureds_address
+    assert str(insureds_address) == "Königstr. 1B^^Stuttgart^^70173"
+    assert str(insureds_address.street_address) == "Königstr. 1B"
+    assert str(insureds_address.city) == "Stuttgart"
+    assert str(insureds_address.zip_or_postal_code) == "70173"


### PR DESCRIPTION
Adds the *insured's address* as a `HL7_ExtendedAddress` to IN1 segment. 