### PR TITLE
fix(IN1): Correct indexing for policy number

### DIFF
--- a/hl7parser/hl7_segments.py
+++ b/hl7parser/hl7_segments.py
@@ -251,7 +251,7 @@ segment_maps = {
             "insureds_address",
             options={"type": HL7_ExtendedAddress, "required": False, "repeats": False},
         ),
-        make_cell_type("policy_number", index=36)
+        make_cell_type("policy_number", index=35)
         # NOTE: standard defines more fields which can be added if needed in
         # the future
     ],

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -288,7 +288,7 @@ def test_in1_segment():
         "IN1|1:1|McDH|123456789^^^^^^^^^McDonalds Health|McDonalds Health||||||"
         "||||||Musterfrau^Gertrud^^^^Dr.^L^A^|SEL|19700101|Königstr. 1B^^Stuttgart^^70173|"
         "||||||||||"
-        "||||||1|12345|||||||||||||"
+        "|||||1|12345||||||||||||||"
     )
 
     in1 = HL7Segment(message_data)
@@ -302,9 +302,9 @@ def test_in1_segment():
     assert str(name_of_insured) == "Musterfrau^Gertrud^^^^Dr.^L^A^"
     assert str(name_of_insured.family_name) == "Musterfrau"
     assert str(name_of_insured.given_name) == "Gertrud"
-    assert str(name_of_insured.middle_name) == ''
-    assert str(name_of_insured.suffix) == ''
-    assert str(name_of_insured.prefix) == ''
+    assert str(name_of_insured.middle_name) == ""
+    assert str(name_of_insured.suffix) == ""
+    assert str(name_of_insured.prefix) == ""
     assert str(name_of_insured.degree) == "Dr."
     assert str(name_of_insured.name_type_code) == "L"
     assert str(name_of_insured.name_representation_code) == "A"


### PR DESCRIPTION
Introduced by #26 

Revert index of `policy_number` to 35 again. 

Fixes #28 